### PR TITLE
fix: replace lsblk --filter with awk for broader compatibility

### DIFF
--- a/windusb.sh
+++ b/windusb.sh
@@ -84,7 +84,7 @@ get_the_drive() {
         printf "===============================================\n\n"
         printf "Please select the USB drive from the following list:\n"
         readarray -t lines < <(
-            lsblk -dpno NAME,SIZE,MODEL,VENDOR,TRAN --filter 'TRAN=="usb"'
+            lsblk -dpno NAME,SIZE,MODEL,VENDOR,TRAN | awk '$NF=="usb"'
         )
         if [[ ${#lines[@]} -eq 0 ]]; then
             printf "No USB drives detected.\n"


### PR DESCRIPTION
On Ubuntu 24.04, lsblk does not recognize the --filter flag, causing USB drives to never appear in the list even when connected.
Using awk '$NF=="usb"' is more portable and works across distros.